### PR TITLE
feat: 배포된 백엔드와의 통신을 위해 FE에서 API URL을 localhost 기반에서 EC2 퍼블릭 IP 주소로 변경

### DIFF
--- a/payphone-frontend-pjt/src/stores/accountStore.js
+++ b/payphone-frontend-pjt/src/stores/accountStore.js
@@ -2,7 +2,7 @@ import { defineStore } from "pinia";
 import {ref} from "vue";
 import axios from "axios";
 
-const ACCOUNT_API = "http://localhost:8080/api/account";
+const ACCOUNT_API = "http://3.39.190.135:8080/api/account";
 
 export const useAccountStore = defineStore("account", () => {
     // 1. 계좌 생성

--- a/payphone-frontend-pjt/src/stores/userStore.js
+++ b/payphone-frontend-pjt/src/stores/userStore.js
@@ -3,7 +3,7 @@ import {defineStore} from "pinia";
 import axios from "axios"; 
 import router from "@/router"; 
 
-const REST_USER_AIP = `http://localhost:8080/api/auth`;
+const REST_USER_AIP = `http://3.39.190.135:8080/api/auth`;
 // Axios 요청 시 Authorization 헤더 자동 설정
 axios.interceptors.request.use(
     (config) => {


### PR DESCRIPTION
### 변경 사항
- Localhost 기반의 REST API URL을 EC2 퍼블릭 IP 주소로 변경했습니다.
- 배포된 백엔드와의 통신을 위해 프론트엔드에서 API 요청 경로를 수정했습니다.

### ✅ 주요 수정 내용
1. **URL 변경**
   ```diff
   - const REST_USER_API = 'http://localhost:8080/api/auth';
   + const REST_USER_API = 'http://3.39.190.135:8080/api/auth';
   ```
2. **배포 환경 테스트 완료**
   - EC2 인스턴스에서 REST API 요청이 성공적으로 처리됨을 확인했습니다.

### 📂 변경된 파일
- `src/.../userStore.js` (URL 변경)

### 🛠 체크리스트
- [x] EC2 배포 환경에서 API 호출 정상 동작 확인
- [x] 기존 기능과의 충돌 없음
- [x] 프로덕션 환경에서의 안정성 검증

### 🔍 참고 사항
- 배포 환경에서의 URL 변경이므로, 로컬 개발 시에는 `localhost`를 다시 사용할 수 있도록 `.env`를 활용한 환경 변수 도입을 고려 중입니다.
